### PR TITLE
Add Functionality: Shift-Click to +/- by 60 mins

### DIFF
--- a/WaitAroundSMAPI/Properties/AssemblyInfo.cs
+++ b/WaitAroundSMAPI/Properties/AssemblyInfo.cs
@@ -1,5 +1,5 @@
 ﻿using System.Reflection;
 
 [assembly: AssemblyTitle("WaitAroundSMAPI")]
-[assembly: AssemblyVersion("1.2.1")]
-[assembly: AssemblyFileVersion("1.2.1")]
+[assembly: AssemblyVersion("1.2.2")]
+[assembly: AssemblyFileVersion("1.2.2")]

--- a/WaitAroundSMAPI/WaitAroundMenu.cs
+++ b/WaitAroundSMAPI/WaitAroundMenu.cs
@@ -4,6 +4,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using StardewValley;
 using StardewValley.Menus;
+using StardewModdingAPI;
 
 namespace WaitAroundSMAPI
 {
@@ -40,14 +41,19 @@ namespace WaitAroundSMAPI
             );
         }
 
+        private bool isShiftPressed()
+        {
+            return this.Mod.Helper.Input.IsDown(SButton.LeftShift) || this.Mod.Helper.Input.IsDown(SButton.RightShift);
+        }
+
         private void upButton(MenuButton menuButton)
         {
-            Mod.timeToWait += 10;
+            Mod.timeToWait += this.isShiftPressed() ? 60 : 10;
         }
 
         private void downButton(MenuButton menuButton)
         {
-            Mod.timeToWait -= 10;
+            Mod.timeToWait -= this.isShiftPressed() ? 60 : 10;
         }
 
         private void enterButton(MenuButton menuButton)

--- a/WaitAroundSMAPI/WaitAroundSMAPI.csproj
+++ b/WaitAroundSMAPI/WaitAroundSMAPI.csproj
@@ -20,6 +20,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -48,9 +49,6 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="2.2.0" />
-  </ItemGroup>
-  <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
   </ItemGroup>
@@ -63,6 +61,11 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Pathoschild.Stardew.ModBuildConfig">
+      <Version>2.2.0</Version>
+    </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
The main piece is of course `WaitAroundMenu.cs`

As for `WaitAroundSMAPI.csproj`, when I first cloned the git repo and open it on Visual Studio **2019**, I couldn't get it to recognize the SMAPI NuGet; I have to uninstall and reinstall SMAPI via NuGet before VS2019 recognizes the references.

_Probably_ the schema of the .csproj file changed between VS2017 and VS2019?
